### PR TITLE
Fix Vulkan tests being filtered out on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,17 +178,17 @@ jobs:
       run: |
         set -e
         # Skip backends
-        if [ ${{ matrix.os != 'ubuntu-latest' }} ]; then
+        if [ "${{ matrix.os }}" != "ubuntu-latest" ]; then
           export SUPASIM_SKIP_BACKEND_VULKAN=1
           export SUPASIM_SKIP_BACKEND_WGPU_VULKAN=1
         fi
-        #if [ ${{ matrix.os != 'windows-latest' }} ]; then
+        #if [ "${{ matrix.os }}" != "windows-latest" ]; then
           #export SUPASIM_SKIP_BACKEND_WGPU_DX12=1
         #fi
 
         # Skip kernel targets
         export SUPASIM_SKIP_KERNELS_PTX=1
-        if [ ${{ matrix.os == 'macos-latest' }} ]; then
+        if [ "${{ matrix.os }}" = "macos-latest" ]; then
           export SUPASIM_SKIP_KERNELS_DXIL=1
         fi
 


### PR DESCRIPTION
The "Run tests" step gated backend/kernel skips with `if [ ${{ matrix.os != 'ubuntu-latest' }} ]`. GitHub renders the expression to a bare `true`/`false` literal, so bash evaluated `[ false ]` / `[ true ]` — a single-string test that is true for any non-empty string. The Vulkan skip therefore fired on every OS, including ubuntu, so SUPASIM_SKIP_BACKEND_VULKAN was always set and Vulkan (and wgpu-vulkan) tests never ran. The same pattern also skipped the DXIL kernel target everywhere.

Quote matrix.os and use a real string comparison so the skips only apply on the intended OSes: Vulkan runs on ubuntu (lavapipe), is skipped on Windows/macOS; DXIL is skipped on macOS.

Fixes #140