### PR TITLE
Vulkan fixes

### DIFF
--- a/crates/supasim-hal/src/vulkan/command_recorder.rs
+++ b/crates/supasim-hal/src/vulkan/command_recorder.rs
@@ -225,6 +225,29 @@ impl VulkanCommandRecorder {
             }
             return Ok(());
         }
+        if barriers.is_empty() {
+            // PipelineBarrier with no MemoryBarriers: emit a global execution + memory barrier.
+            // An empty DependencyInfoKHR carries no stage/access scopes — the call would be a
+            // no-op and the intended execution dependency would be silently lost.
+            let global = vk::MemoryBarrier2KHR::default()
+                .src_stage_mask(pre_flags)
+                .dst_stage_mask(post_flags)
+                .src_access_mask(
+                    vk::AccessFlags2KHR::MEMORY_READ_KHR | vk::AccessFlags2KHR::MEMORY_WRITE_KHR,
+                )
+                .dst_access_mask(
+                    vk::AccessFlags2KHR::MEMORY_READ_KHR | vk::AccessFlags2KHR::MEMORY_WRITE_KHR,
+                );
+            let dep = vk::DependencyInfoKHR::default()
+                .memory_barriers(std::slice::from_ref(&global));
+            unsafe {
+                stream
+                    .shared
+                    .functions
+                    .supa_cmd_pipeline_barrier2(cb, &dep)
+            };
+            return Ok(());
+        }
         for barrier in &mut barriers {
             *barrier = barrier.src_stage_mask(pre_flags).dst_stage_mask(post_flags);
         }

--- a/crates/supasim-hal/src/vulkan/command_recorder.rs
+++ b/crates/supasim-hal/src/vulkan/command_recorder.rs
@@ -137,6 +137,25 @@ impl VulkanCommandRecorder {
         }
     }
 
+    /// Derive the tightest correct access mask for a given stage mask.
+    /// Using MEMORY_READ|MEMORY_WRITE for every barrier forces the GPU to flush/invalidate
+    /// all caches regardless of what was actually accessed; this maps stage bits to the
+    /// specific access types that stage can produce, shrinking the flush scope.
+    fn access_mask_for_stage(stage: vk::PipelineStageFlags2KHR) -> vk::AccessFlags2KHR {
+        use vk::{AccessFlags2KHR as A, PipelineStageFlags2KHR as S};
+        if stage.contains(S::ALL_COMMANDS_KHR) {
+            return A::MEMORY_READ_KHR | A::MEMORY_WRITE_KHR;
+        }
+        let mut access = A::empty();
+        if stage.contains(S::TRANSFER) {
+            access |= A::TRANSFER_READ | A::TRANSFER_WRITE;
+        }
+        if stage.contains(S::COMPUTE_SHADER) {
+            access |= A::SHADER_STORAGE_READ | A::SHADER_STORAGE_WRITE;
+        }
+        access
+    }
+
     /// First command must be a pipeline barrier. Following commands must be memory barriers
     fn sync_command<'a>(
         &mut self,
@@ -157,20 +176,14 @@ impl VulkanCommandRecorder {
                             length: len,
                         },
                 } => barriers.push(
+                    // Access masks are left as zero here; they are filled in after the loop
+                    // once pre_flags/post_flags are known, so we use the stage-derived masks.
                     vk::BufferMemoryBarrier2KHR::default()
                         .buffer(buffer.buffer)
                         .offset(*offset)
                         .size(*len)
                         .src_queue_family_index(stream.queue_family_idx)
-                        .dst_queue_family_index(stream.queue_family_idx)
-                        .src_access_mask(
-                            vk::AccessFlags2KHR::MEMORY_READ_KHR
-                                | vk::AccessFlags2KHR::MEMORY_WRITE_KHR,
-                        )
-                        .dst_access_mask(
-                            vk::AccessFlags2KHR::MEMORY_READ_KHR
-                                | vk::AccessFlags2KHR::MEMORY_WRITE_KHR,
-                        ),
+                        .dst_queue_family_index(stream.queue_family_idx),
                 ),
                 BufferCommand::MemoryTransfer {
                     buffer:
@@ -232,12 +245,8 @@ impl VulkanCommandRecorder {
             let global = vk::MemoryBarrier2KHR::default()
                 .src_stage_mask(pre_flags)
                 .dst_stage_mask(post_flags)
-                .src_access_mask(
-                    vk::AccessFlags2KHR::MEMORY_READ_KHR | vk::AccessFlags2KHR::MEMORY_WRITE_KHR,
-                )
-                .dst_access_mask(
-                    vk::AccessFlags2KHR::MEMORY_READ_KHR | vk::AccessFlags2KHR::MEMORY_WRITE_KHR,
-                );
+                .src_access_mask(Self::access_mask_for_stage(pre_flags))
+                .dst_access_mask(Self::access_mask_for_stage(post_flags));
             let dep = vk::DependencyInfoKHR::default()
                 .memory_barriers(std::slice::from_ref(&global));
             unsafe {
@@ -248,8 +257,14 @@ impl VulkanCommandRecorder {
             };
             return Ok(());
         }
+        let src_access = Self::access_mask_for_stage(pre_flags);
+        let dst_access = Self::access_mask_for_stage(post_flags);
         for barrier in &mut barriers {
-            *barrier = barrier.src_stage_mask(pre_flags).dst_stage_mask(post_flags);
+            *barrier = barrier
+                .src_stage_mask(pre_flags)
+                .dst_stage_mask(post_flags)
+                .src_access_mask(src_access)
+                .dst_access_mask(dst_access);
         }
         let dependency_info = vk::DependencyInfoKHR::default().buffer_memory_barriers(&barriers);
         unsafe {

--- a/crates/supasim-hal/src/vulkan/command_recorder.rs
+++ b/crates/supasim-hal/src/vulkan/command_recorder.rs
@@ -247,14 +247,9 @@ impl VulkanCommandRecorder {
                 .dst_stage_mask(post_flags)
                 .src_access_mask(Self::access_mask_for_stage(pre_flags))
                 .dst_access_mask(Self::access_mask_for_stage(post_flags));
-            let dep = vk::DependencyInfoKHR::default()
-                .memory_barriers(std::slice::from_ref(&global));
-            unsafe {
-                stream
-                    .shared
-                    .functions
-                    .supa_cmd_pipeline_barrier2(cb, &dep)
-            };
+            let dep =
+                vk::DependencyInfoKHR::default().memory_barriers(std::slice::from_ref(&global));
+            unsafe { stream.shared.functions.supa_cmd_pipeline_barrier2(cb, &dep) };
             return Ok(());
         }
         let src_access = Self::access_mask_for_stage(pre_flags);

--- a/crates/supasim-hal/src/vulkan/init.rs
+++ b/crates/supasim-hal/src/vulkan/init.rs
@@ -173,18 +173,20 @@ impl Vulkan {
                         debug_utils_loader.destroy_debug_utils_messenger(debug_callback, None);
                     }
             }
-            let ext = [
+            // Required extensions (device is rejected if missing and not yet promoted to core).
+            // khr::shader_atomic_int64 is intentionally absent — it is optional; devices
+            // without int64 atomics are still usable (atomic_int64 capability is reported false).
+            let required_ext = [
                 (khr::synchronization2::NAME, vk::API_VERSION_1_3),
                 (khr::timeline_semaphore::NAME, vk::API_VERSION_1_2),
                 (
                     khr::get_physical_device_properties2::NAME,
                     vk::API_VERSION_1_1,
                 ),
-                (khr::shader_atomic_int64::NAME, vk::API_VERSION_1_2),
             ];
-            let (phyd, queue_family_idx, api_version, extension_spirv_version) = {
+            let (phyd, queue_family_idx, api_version) = {
                 let mut best_score = 0;
-                let mut pair = (vk::PhysicalDevice::null(), 0, 0, types::SpirvVersion::V1_0);
+                let mut pair = (vk::PhysicalDevice::null(), 0, 0u32);
                 'outer: for phyd in instance.enumerate_physical_devices()? {
                     let properties = instance.get_physical_device_properties(phyd);
                     let api_version = properties.api_version.min(instance_api_version);
@@ -193,18 +195,13 @@ impl Vulkan {
                         .iter()
                         .map(|a| a.extension_name_as_c_str().unwrap())
                         .collect();
-                    let mut extension_spirv_version = types::SpirvVersion::V1_0;
                     let caps = instance.get_physical_device_features(phyd);
                     if caps.shader_int64 == 0 {
                         continue;
                     }
-                    for extension in ext {
+                    for extension in required_ext {
                         if extension.1 > api_version && !extensions.contains(&extension.0) {
                             continue 'outer;
-                        }
-                        if extension.0 == khr::spirv_1_4::NAME && api_version >= vk::API_VERSION_1_1
-                        {
-                            extension_spirv_version = types::SpirvVersion::V1_4;
                         }
                     }
                     let queue_families = instance.get_physical_device_queue_family_properties(phyd);
@@ -248,12 +245,7 @@ impl Vulkan {
                         + vk::api_version_minor(api_version).min(3);
                     if score > best_score {
                         best_score = score;
-                        pair = (
-                            phyd,
-                            best_queue.1 as u32,
-                            api_version,
-                            extension_spirv_version,
-                        );
+                        pair = (phyd, best_queue.1 as u32, api_version);
                     }
                 }
                 if best_score > 0 {
@@ -261,6 +253,23 @@ impl Vulkan {
                 } else {
                     return Err(VulkanError::NoSupportedDevice);
                 }
+            };
+            // Query extensions of the selected device to determine optional capabilities.
+            // Done once here rather than threading extension lists out of the selection loop.
+            let selected_device_exts = instance.enumerate_device_extension_properties(phyd)?;
+            let selected_device_ext_names: Vec<&CStr> = selected_device_exts
+                .iter()
+                .map(|e| e.extension_name_as_c_str().unwrap())
+                .collect();
+            // SPIRV 1.4 support via VK_KHR_spirv_1_4 (Vulkan 1.1 devices only; 1.2+ already
+            // exposes SPIRV 1.5 natively). VK_KHR_spirv_1_4 depends on
+            // VK_KHR_shader_float_controls, which must also be enabled in that case.
+            let extension_spirv_version = if api_version < vk::API_VERSION_1_2
+                && selected_device_ext_names.contains(&khr::spirv_1_4::NAME)
+            {
+                types::SpirvVersion::V1_4
+            } else {
+                types::SpirvVersion::V1_0
             };
             let api_supported_spirv_version = match api_version {
                 vk::API_VERSION_1_0 => types::SpirvVersion::V1_0,
@@ -275,7 +284,7 @@ impl Vulkan {
                     }
                 }
             };
-            let mut ext: Vec<_> = ext
+            let mut ext: Vec<_> = required_ext
                 .iter()
                 .filter_map(|(ext, api)| {
                     if *api > api_version {
@@ -285,6 +294,13 @@ impl Vulkan {
                     }
                 })
                 .collect();
+            // Optionally enable shader_atomic_int64 on pre-1.2 devices that have the extension.
+            // On 1.2+ it is promoted to core and enabled via PhysicalDeviceShaderAtomicInt64Features.
+            if api_version < vk::API_VERSION_1_2
+                && selected_device_ext_names.contains(&khr::shader_atomic_int64::NAME)
+            {
+                ext.push(khr::shader_atomic_int64::NAME.as_ptr());
+            }
             let spirv_version = if api_supported_spirv_version >= extension_spirv_version {
                 api_supported_spirv_version
             } else {

--- a/crates/supasim-hal/src/vulkan/mod.rs
+++ b/crates/supasim-hal/src/vulkan/mod.rs
@@ -604,10 +604,12 @@ impl BackendInstance<Vulkan> for VulkanInstance {
             }
             let push_constant_ranges: Vec<vk::PushConstantRange> =
                 if desc.reflection.push_constants_size > 0 {
-                    vec![vk::PushConstantRange::default()
-                        .stage_flags(vk::ShaderStageFlags::COMPUTE)
-                        .offset(0)
-                        .size(desc.reflection.push_constants_size as u32)]
+                    vec![
+                        vk::PushConstantRange::default()
+                            .stage_flags(vk::ShaderStageFlags::COMPUTE)
+                            .offset(0)
+                            .size(desc.reflection.push_constants_size as u32),
+                    ]
                 } else {
                     vec![]
                 };

--- a/crates/supasim-hal/src/vulkan/mod.rs
+++ b/crates/supasim-hal/src/vulkan/mod.rs
@@ -245,18 +245,7 @@ impl Device<Vulkan> for VulkanDevice {
 
     #[cfg_attr(feature = "trace", tracing::instrument)]
     unsafe fn create_semaphore(&self) -> std::result::Result<VulkanSemaphore, VulkanError> {
-        unsafe {
-            let mut next = vk::SemaphoreTypeCreateInfo::default()
-                .initial_value(0)
-                .semaphore_type(vk::SemaphoreType::TIMELINE);
-            let create_info = vk::SemaphoreCreateInfo::default()
-                .flags(vk::SemaphoreCreateFlags::empty())
-                .push_next(&mut next);
-            Ok(VulkanSemaphore {
-                inner: self.shared.functions.create_semaphore(&create_info, None)?,
-                current_value: Mutex::new(0),
-            })
-        }
+        unsafe { self.shared.create_timeline_semaphore() }
     }
 
     #[cfg_attr(feature = "trace", tracing::instrument)]
@@ -660,18 +649,7 @@ impl BackendInstance<Vulkan> for VulkanInstance {
 
     #[cfg_attr(feature = "trace", tracing::instrument)]
     unsafe fn create_semaphore(&self) -> std::result::Result<VulkanSemaphore, VulkanError> {
-        unsafe {
-            let mut next = vk::SemaphoreTypeCreateInfo::default()
-                .initial_value(0)
-                .semaphore_type(vk::SemaphoreType::TIMELINE);
-            let create_info = vk::SemaphoreCreateInfo::default()
-                .flags(vk::SemaphoreCreateFlags::empty())
-                .push_next(&mut next);
-            Ok(VulkanSemaphore {
-                inner: self.shared.functions.create_semaphore(&create_info, None)?,
-                current_value: Mutex::new(0),
-            })
-        }
+        unsafe { self.shared.create_timeline_semaphore() }
     }
     #[cfg_attr(feature = "trace", tracing::instrument)]
     unsafe fn cleanup_cached_resources(&mut self) -> Result<(), <Vulkan as Backend>::Error> {
@@ -935,6 +913,23 @@ impl Semaphore<Vulkan> for VulkanSemaphore {
 pub struct SharedDeviceInfo {
     functions: DeviceFunctions,
     queue_family_indices: Vec<u32>,
+}
+
+impl SharedDeviceInfo {
+    unsafe fn create_timeline_semaphore(&self) -> Result<VulkanSemaphore, VulkanError> {
+        unsafe {
+            let mut next = vk::SemaphoreTypeCreateInfo::default()
+                .initial_value(0)
+                .semaphore_type(vk::SemaphoreType::TIMELINE);
+            let create_info = vk::SemaphoreCreateInfo::default()
+                .flags(vk::SemaphoreCreateFlags::empty())
+                .push_next(&mut next);
+            Ok(VulkanSemaphore {
+                inner: self.functions.create_semaphore(&create_info, None)?,
+                current_value: Mutex::new(0),
+            })
+        }
+    }
 }
 
 pub struct DeviceFunctions {

--- a/crates/supasim-hal/src/vulkan/mod.rs
+++ b/crates/supasim-hal/src/vulkan/mod.rs
@@ -197,11 +197,18 @@ impl Device<Vulkan> for VulkanDevice {
             );
             let alloc_info = vk_mem::AllocationCreateInfo {
                 usage: vk_mem::MemoryUsage::Auto,
-                flags: if mapped {
-                    AllocationCreateFlags::MAPPED
-                        | AllocationCreateFlags::HOST_ACCESS_SEQUENTIAL_WRITE
-                } else {
-                    AllocationCreateFlags::empty()
+                flags: match desc.memory_type {
+                    // Upload: CPU writes sequentially → write-combining is fine.
+                    HalBufferType::Upload => {
+                        AllocationCreateFlags::MAPPED
+                            | AllocationCreateFlags::HOST_ACCESS_SEQUENTIAL_WRITE
+                    }
+                    // Download / UploadDownload: CPU reads back → must prefer HOST_CACHED
+                    // memory so reads don't go through write-combining (catastrophically slow).
+                    HalBufferType::Download | HalBufferType::UploadDownload => {
+                        AllocationCreateFlags::MAPPED | AllocationCreateFlags::HOST_ACCESS_RANDOM
+                    }
+                    HalBufferType::Storage => AllocationCreateFlags::empty(),
                 },
                 ..Default::default()
             };
@@ -606,8 +613,19 @@ impl BackendInstance<Vulkan> for VulkanInstance {
                     self.shared.functions.destroy_descriptor_set_layout(descriptor_set_layout, None);
                 }
             }
+            let push_constant_ranges: Vec<vk::PushConstantRange> =
+                if desc.reflection.push_constants_size > 0 {
+                    vec![vk::PushConstantRange::default()
+                        .stage_flags(vk::ShaderStageFlags::COMPUTE)
+                        .offset(0)
+                        .size(desc.reflection.push_constants_size as u32)]
+                } else {
+                    vec![]
+                };
             let pipeline_layout = self.shared.functions.create_pipeline_layout(
-                &vk::PipelineLayoutCreateInfo::default().set_layouts(&[descriptor_set_layout]),
+                &vk::PipelineLayoutCreateInfo::default()
+                    .set_layouts(&[descriptor_set_layout])
+                    .push_constant_ranges(&push_constant_ranges),
                 None,
             )?;
             defer! {


### PR DESCRIPTION


- Push constants: pipeline layout now declares a VkPushConstantRange when push_constants_size > 0; previously vkCmdPushConstants was called with no matching range, which is UB and causes validation errors.

- Download/UploadDownload buffer memory: switched from HOST_ACCESS_SEQUENTIAL_WRITE to HOST_ACCESS_RANDOM so VMA picks HOST_CACHED rather than write-combined memory; CPU reads from write-combined allocations are ~100x slower.

- khr::shader_atomic_int64 device selection: removed from the hard-required extension list; devices that lack it (lavapipe, many mobile GPUs) were rejected even when int64 atomics are never used. Extension is now enabled conditionally when available.

- SPIRV 1.4 detection: the old check for khr::spirv_1_4::NAME iterated the required-extension array which never contains that name — dead code, extension_ spirv_version was stuck at V1_0 forever. Now re-queries the selected device's extensions after the selection loop and sets V1_4 when the extension is present.

- PipelineBarrier-only barrier group: an empty DependencyInfoKHR has no execution scope and vkCmdPipelineBarrier2 becomes a no-op, silently losing the dependency. Now emits a global MemoryBarrier2KHR with the accumulated stage flags instead.